### PR TITLE
Fix for broken CapabilityContainerListener bulk updates

### DIFF
--- a/src/main/java/choonster/testmod3/capability/CapabilityContainerListener.java
+++ b/src/main/java/choonster/testmod3/capability/CapabilityContainerListener.java
@@ -49,11 +49,9 @@ public abstract class CapabilityContainerListener<HANDLER> implements IContainer
 		// Filter out any items from the list that shouldn't be synced
 		final NonNullList<ItemStack> syncableItemsList = NonNullList.withSize(itemsList.size(), ItemStack.EMPTY);
 		for (int index = 0; index < syncableItemsList.size(); index++) {
-			final ItemStack stack = syncableItemsList.get(index);
+			final ItemStack stack = itemsList.get(index);
 			if (shouldSyncItem(stack)) {
 				syncableItemsList.set(index, stack);
-			} else {
-				syncableItemsList.set(index, ItemStack.EMPTY);
 			}
 		}
 


### PR DESCRIPTION
The loop was getting ItemStack instances to check from the wrong (empty) list - syncableItemsList instead of itemsList.  

Removed redundant syncableItemsList ItemStack.empty setting since the list was initialized with those values.

Thanks for the examples!  The CapabilityContainerListener code was very useful (might be good for a separate library to reuse).