### PR TITLE
Avoid server startup crash due to class scanning issue by changing PlayerEntity to ClientPlayerEntity

### DIFF
--- a/src/main/java/choonster/testmod3/network/capability/BulkUpdateContainerCapabilityMessage.java
+++ b/src/main/java/choonster/testmod3/network/capability/BulkUpdateContainerCapabilityMessage.java
@@ -1,10 +1,15 @@
 package choonster.testmod3.network.capability;
 
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
+import javax.annotation.Nullable;
+
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minecraft.client.Minecraft;
-import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.client.entity.player.ClientPlayerEntity;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
@@ -14,10 +19,6 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.network.NetworkEvent;
-
-import javax.annotation.Nullable;
-import java.util.function.Supplier;
-import java.util.stream.IntStream;
 
 /**
  * Base class for messages that update the capability data for each slot of a {@link Container}.
@@ -204,7 +205,7 @@ public abstract class BulkUpdateContainerCapabilityMessage<HANDLER, DATA> {
 		}
 
 		ctx.get().enqueueWork(() -> DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
-			final PlayerEntity player = Minecraft.getInstance().player;
+			final ClientPlayerEntity player = Minecraft.getInstance().player;
 
 			final Container container;
 			if (message.windowID == 0) {

--- a/src/main/java/choonster/testmod3/network/capability/UpdateContainerCapabilityMessage.java
+++ b/src/main/java/choonster/testmod3/network/capability/UpdateContainerCapabilityMessage.java
@@ -1,7 +1,11 @@
 package choonster.testmod3.network.capability;
 
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
 import net.minecraft.client.Minecraft;
-import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.client.entity.player.ClientPlayerEntity;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.Direction;
@@ -9,9 +13,6 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.network.NetworkEvent;
-
-import javax.annotation.Nullable;
-import java.util.function.Supplier;
 
 /**
  * Base class for messages that update capability data for a single slot of a {@link Container}.
@@ -192,7 +193,7 @@ public abstract class UpdateContainerCapabilityMessage<HANDLER, DATA> {
 		}
 
 		ctx.get().enqueueWork(() -> DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
-			final PlayerEntity player = Minecraft.getInstance().player;
+			final ClientPlayerEntity player = Minecraft.getInstance().player;
 
 			final Container container;
 			if (message.windowID == 0) {


### PR DESCRIPTION
A few folks on #modder-support-114 think it is an issue in Forge class scanning, perhaps when it is checking if PlayerEntity is a valid cast for Minecraft.getInstance().player .

Without this change, server-only startup crashes due to missing symbol ClientPlayerEntity (even tho the code is properly wrapped by `DistExecutor.runWhenOn(Dist.CLIENT, ...)`